### PR TITLE
Fix excess orders stopping other orders' creation

### DIFF
--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1520,7 +1520,7 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
     -- Create the alt order buttons
     for index, availOrder in availableOrders do
         if not standardOrdersTable[availOrder] then continue end -- Skip any orders we don't have in our table
-        if not commonOrders[availOrder] then
+        if not commonOrders[availOrder] and slotForOrder[availOrder] ~= nil then
             local orderInfo = standardOrdersTable[availOrder] or AbilityInformation[availOrder]
             local orderCheckbox = AddOrder(orderInfo, slotForOrder[availOrder], true)
 
@@ -1552,7 +1552,7 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
 
     for index, availToggle in availableToggles do
         if not standardOrdersTable[availToggle] then continue end -- Skip any orders we don't have in our table
-        if not commonOrders[availToggle] then
+        if not commonOrders[availToggle] and slotForOrder[availToggle] ~= nil then
             local orderInfo = standardOrdersTable[availToggle] or AbilityInformation[availToggle]
             local orderCheckbox = AddOrder(orderInfo, slotForOrder[availToggle], true)
 
@@ -1671,9 +1671,8 @@ function SetAvailableOrders(availableOrders, availableToggles, newSelection)
         end
     end
 
-    if numValidOrders <= 12 then
-        CreateAltOrders(availableOrders, availableToggles, currentSelection)
-    end
+    CreateAltOrders(availableOrders, availableToggles, currentSelection)
+
 
     controls.orderButtonGrid:EndBatch()
     if table.empty(currentSelection) and controls.bg.Mini then


### PR DESCRIPTION
Solves the "strange bug" with tactical missile / billy nuke and teleport: https://github.com/FAForever/fa/pull/5679
First it wasn't creating the orders because 7 base orders + 3 engineering orders + 1 OC + 2 missile + 1 tele = 14, which is more than the 12 allowed to be created.
After fixing that, there is a bug where orders are created out of *all* available orders using *limited* order-assigned slots. This meant that it could grab a `nil` slot for an available order, since that order didn't get assigned in the slot checking beforehand. This is fixed with a nil check. 
Ideally there would be a priority system for what orders are given slots, but that isn't worth the effort given how rarely you select units with enough orders to do that (needs cross-faction, cross-theater, and/or very expensive units).